### PR TITLE
Support Rails 4

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < ApplicationController
   skip_before_filter :ensure_authenticated
+  protect_from_forgery except: [:new, :create, :failure]
 
   def new
     redirect_to '/auth/g'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,6 @@
 class SessionsController < ApplicationController
   skip_before_filter :ensure_authenticated
-  protect_from_forgery except: [:new, :create, :failure]
+  protect_from_forgery except: [:new, :create, :failure, :destroy]
 
   def new
     redirect_to '/auth/g'
@@ -18,6 +18,11 @@ class SessionsController < ApplicationController
     else
       render '/auth/failure'
     end
+  end
+
+  def destroy
+    logout
+    redirect_to root_path
   end
 
   def failure

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   get '/login', :to => 'sessions#new', :as => :login
   post '/auth/g/callback', :to => 'sessions#create'
   post '/auth/failure', :to => 'sessions#failure'
+  delete '/logout', :to => 'sessions#destroy', :as => :logout
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
-GoogleAuth::Engine.routes.draw do
-  match '/login', :to => 'sessions#new', :as => :login
-  match '/auth/g/callback', :to => 'sessions#create'
-  match '/auth/failure', :to => 'sessions#failure'
+Rails.application.routes.draw do
+  get '/login', :to => 'sessions#new', :as => :login
+  post '/auth/g/callback', :to => 'sessions#create'
+  post '/auth/failure', :to => 'sessions#failure'
 end

--- a/lib/google_auth/controller.rb
+++ b/lib/google_auth/controller.rb
@@ -19,5 +19,10 @@ module GoogleAuth
       end
     end
 
+    def logout
+      session[:user_id] = nil
+      @current_user = nil
+    end
+
   end
 end

--- a/lib/google_auth/version.rb
+++ b/lib/google_auth/version.rb
@@ -1,3 +1,3 @@
 module GoogleAuth
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
@burke @gauravmc 

Our auth gem does not support rails 4. Changes:
- Routes must use `get` and `post` rather than `match`.
- The call to `routes.draw` must come from the app now (apparently).
- Protect from forgery syntax is different.
