### PR TITLE
Fix find_or_initialize_by for Rails 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 GoogleAuth is a very, very trivial convenience wrapper around `omniauth-google-apps` that
 makes a lot of assumptions, and requires much less setup.
 
+## Version
+
+Version 0.1.0 is Rails 4.x compatible. For Rails 3.x projects use version 0.0.4
+
 ## How
 
 #### 1. Your user model must have the string fields `name`, `email`, and `uid`.

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,7 @@ class SessionsController < ApplicationController
 
   def create
     if auth = request.env['omniauth.auth']
-      user = GoogleAuth.user_class.find_or_initialize_by_email(auth['info']['email'])
+      user = GoogleAuth.user_class.find_or_initialize_by(email: auth['info']['email'])
       user.uid = auth['uid']
       user.name = auth['info']['name']
       user.save!

--- a/google_auth.gemspec
+++ b/google_auth.gemspec
@@ -16,5 +16,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_dependency 'activerecord', '~> 4.0'
   s.add_runtime_dependency 'omniauth-google-apps'
 end

--- a/lib/google_auth/version.rb
+++ b/lib/google_auth/version.rb
@@ -1,3 +1,3 @@
 module GoogleAuth
-  VERSION = "0.0.4"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
Started using this to get Google Auth working quickly on a project. `find_or_initialize_by_email` doesn't work in Rails 4.1 so I fixed it so it would. 

Not sure if this is worth merging as it might break projects that are using this (I'd have to test this in Rails 3) and I don't know how many new projects use it. 

@kmcphillips 
